### PR TITLE
fix: support valid types for compiler options

### DIFF
--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -153,8 +153,11 @@ class QuantinuumCompilerOptions(BaseModel):
         """Check that compiler option values are supported types."""
         for key in values:
             assert isinstance(
-                values[key], (str, int, bool)
+                values[key], (str, int, bool, float, list)
             ), "Compiler options must be str, bool or int"
+            if isinstance(values[key], list):
+                for x in values[key]:
+                    assert isinstance(x, float), "Lists must only contain floats"
         return values
 
 

--- a/tests/models/test_backend_config.py
+++ b/tests/models/test_backend_config.py
@@ -1,8 +1,10 @@
-from quantinuum_schemas.models.backend_config import AerConfig, QuantinuumCompilerOptions
+import pytest
 from pydantic import ValidationError
 
-import pytest
-
+from quantinuum_schemas.models.backend_config import (
+    AerConfig,
+    QuantinuumCompilerOptions,
+)
 
 
 def test_instantiation() -> None:

--- a/tests/models/test_backend_config.py
+++ b/tests/models/test_backend_config.py
@@ -1,6 +1,33 @@
-from quantinuum_schemas.models.backend_config import AerConfig
+from quantinuum_schemas.models.backend_config import AerConfig, QuantinuumCompilerOptions
+from pydantic import ValidationError
+
+import pytest
+
 
 
 def test_instantiation() -> None:
     aer_config = AerConfig()
     assert isinstance(aer_config, AerConfig)
+
+def test_valid_quantinuum_compiler_options() -> None:
+    """Test to ensure that all expected arguments can be accepted by the compiler options class"""
+    dict_of_options = {
+        "expect_threshold": 0.5,
+        "DD_threshold_times": [0.1, 0.2, 0.3],
+        "CF": "non linear",
+        "test_cz": False,
+        "max_planning": 601
+
+    }
+
+    QuantinuumCompilerOptions(**dict_of_options)
+
+def test_handling_invalid_option() -> None:
+    """Expect an assert error raised when passing a bad compiler option"""
+    dict_of_options = {
+        "DD_threshold_times": [0.1, 3, 0.3],
+    }
+
+    with pytest.raises(ValidationError): 
+        QuantinuumCompilerOptions(**dict_of_options)
+    


### PR DESCRIPTION
The list of valid compiler options includes floats and List[float] which are currently refused by the assertion on types.
https://github.com/quantinuum-dev/hqscompiler/blob/master/hqscompiler/compargs.py

Slightly annoying you can't use is_instance to check if a list is a certain type, so instead I'm checking each item individually, that might be more than we need and in which case I can remove the check.