### PR TITLE
chore: Pin github runner versions to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check:
     name: Checks and tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.10']

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   main:
     name: Validate Conventional Commit PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # The action does not support running on merge_group events,
     # but if the check succeeds in the PR there is no need to check it again.
     if: github.event_name == 'pull_request_target'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
This way we're clearer what version we're running on (which has been Ubuntu 24.04 since January 17 2025).