### PR TITLE
infra: prepare SeleneConfigs

### DIFF
--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -9,8 +9,13 @@ as our backend credential classes handle those.
 import abc
 from typing import Any, Dict, Literal, Optional, Type, TypeVar, Union
 
-from pydantic import BaseModel
-from pydantic import ConfigDict, PositiveInt, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
 from pydantic.fields import Field
 from typing_extensions import Annotated, Self
 

--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -261,7 +261,6 @@ class QulacsConfig(BaseBackendConfig):
     type: Literal["QulacsConfig"] = "QulacsConfig"
     result_type: str = "state_vector"
     gpu_sim: bool = False
-    seed: Optional[int] = None
 
 
 class BaseSeleneConfig(BaseModel):
@@ -292,7 +291,7 @@ class BaseSeleneConfig(BaseModel):
         return self
 
 
-class SeleneQuestConfig(BaseSeleneConfig, BaseBackendConfig):
+class SeleneQuestConfig(BaseBackendConfig, BaseSeleneConfig):
     """Selene QuEST statevector simulator.
 
     Args:
@@ -308,7 +307,7 @@ class SeleneQuestConfig(BaseSeleneConfig, BaseBackendConfig):
     n_qubits: int = Field(ge=1, le=28)
 
 
-class SeleneStimConfig(BaseSeleneConfig, BaseBackendConfig):
+class SeleneStimConfig(BaseBackendConfig, BaseSeleneConfig):
     """Selene Stim stabilizer simulator. As Stim is a stabilizer simulator, it can only simulate
     Clifford operations. We provide an angle threshold parameter for users to decide how far angles
     can be away from pi/2 rotations on the bloch sphere before they are considered invalid.
@@ -329,7 +328,7 @@ class SeleneStimConfig(BaseSeleneConfig, BaseBackendConfig):
     angle_threshold: float = Field(default=1e-8, gt=0.0)
 
 
-class SeleneLeanConfig(BaseSeleneConfig, BaseBackendConfig):
+class SeleneLeanConfig(BaseBackendConfig, BaseSeleneConfig):
     """Selene Lean (low-entanglement approximation engine) tensor network simulator.
 
     Args:
@@ -369,7 +368,7 @@ class SeleneLeanConfig(BaseSeleneConfig, BaseBackendConfig):
         return self
 
 
-class SeleneCoinFlipConfig(BaseSeleneConfig, BaseBackendConfig):
+class SeleneCoinFlipConfig(BaseBackendConfig, BaseSeleneConfig):
     """Selene 'Coin Flip'  simulator. Doesn't maintain any quantum state and picks a random
     boolean value for each measurement.
 
@@ -388,7 +387,7 @@ class SeleneCoinFlipConfig(BaseSeleneConfig, BaseBackendConfig):
     bias: float = Field(default=0.5, ge=0.0, le=1.0)
 
 
-class SeleneClassicalReplayConfig(BaseSeleneConfig, BaseBackendConfig):
+class SeleneClassicalReplayConfig(BaseBackendConfig, BaseSeleneConfig):
     """Selene 'Classical Replay' simulator. This simulator allows a user to predefine the
     results of measurements for each shot. No quantum operations are performed.
 

--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -9,7 +9,7 @@ as our backend credential classes handle those.
 import abc
 from typing import Any, Dict, Literal, Optional, Type, TypeVar, Union
 
-from pydantic import BaseModel as PydanticBaseModel
+from pydantic import BaseModel
 from pydantic import ConfigDict, PositiveInt, field_validator, model_validator
 from pydantic.fields import Field
 from typing_extensions import Annotated, Self
@@ -24,10 +24,10 @@ from quantinuum_schemas.models.selene_config import (
     SimpleRuntime,
 )
 
-ST = TypeVar("ST", bound="PydanticBaseModel")
+ST = TypeVar("ST", bound="BaseModel")
 
 
-class BaseBackendConfig(PydanticBaseModel, abc.ABC):
+class BaseBackendConfig(BaseModel, abc.ABC):
     """Base class for all the backend configs.
     Implements the to_serializable and from_serializable methods
     for backwards compatibility.
@@ -53,7 +53,6 @@ class AerConfig(BaseBackendConfig):
     simulation_method: str = "automatic"
     crosstalk_params: Optional[CrosstalkParams] = None
     n_qubits: PositiveInt = 40
-    seed: Optional[int] = None
 
     @field_validator("noise_model", mode="before")
     @classmethod
@@ -82,14 +81,14 @@ class AerStateConfig(BaseBackendConfig):
     """Qiskit Aer state vector simulator."""
 
     type: Literal["AerStateConfig"] = "AerStateConfig"
-    n_qubits: PositiveInt = Field(default=40, le=64)
+    n_qubits: PositiveInt = 40
 
 
 class AerUnitaryConfig(BaseBackendConfig):
     """Qiskit Aer unitary simulator."""
 
     type: Literal["AerUnitaryConfig"] = "AerUnitaryConfig"
-    n_qubits: PositiveInt = Field(default=40, le=64)
+    n_qubits: PositiveInt = 40
 
 
 class BraketConfig(BaseBackendConfig):
@@ -155,7 +154,7 @@ class BraketConfig(BaseBackendConfig):
         return values
 
 
-class QuantinuumCompilerOptions(PydanticBaseModel):
+class QuantinuumCompilerOptions(BaseModel):
     """Class for Quantinuum Compiler Options.
 
     Intentionally allows extra unknown flags to be defined.
@@ -248,7 +247,6 @@ class IBMQEmulatorConfig(BaseBackendConfig):
     hub: str
     group: str
     project: str
-    seed: Optional[int] = None
 
 
 class ProjectQConfig(BaseBackendConfig):
@@ -266,7 +264,7 @@ class QulacsConfig(BaseBackendConfig):
     seed: Optional[int] = None
 
 
-class BaseSeleneConfig(PydanticBaseModel):
+class BaseSeleneConfig(BaseModel):
     """Shared configuration for Selene emulator instances. Not to be used directly.
 
     Args:

--- a/quantinuum_schemas/models/selene_config.py
+++ b/quantinuum_schemas/models/selene_config.py
@@ -1,5 +1,7 @@
 """Additional configuration models for the Selene emulator."""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -12,6 +14,8 @@ class SimpleRuntime(BaseModel):
         seed: Random seed for the runtime.
     """
 
+    type: Literal["SimpleRuntime"] = "SimpleRuntime"
+
     seed: int | None = Field(default=None)
 
 
@@ -22,6 +26,8 @@ class HeliosRuntime(BaseModel):
     Args:
         seed: Random seed for the runtime.
     """
+
+    type: Literal["HeliosRuntime"] = "HeliosRuntime"
 
     seed: int | None = Field(default=None)
 
@@ -35,6 +41,8 @@ class NoErrorModel(BaseModel):
     Args:
         seed: Random seed for the error model.
     """
+
+    type: Literal["NoErrorModel"] = "NoErrorModel"
 
     seed: int | None = Field(default=None)
 
@@ -51,6 +59,8 @@ class DepolarizingErrorModel(BaseModel):
         p_init: The error probability for initialization operations.
     """
 
+    type: Literal["DepolarizingErrorModel"] = "DepolarizingErrorModel"
+
     seed: int | None = Field(default=None)
     p_1q: float = Field(default=0.0, ge=0.0, le=1.0)
     p_2q: float = Field(default=0.0, ge=0.0, le=1.0)
@@ -65,6 +75,8 @@ class QSystemErrorModel(BaseModel):
         seed: Random seed for the error model.
         name: Name of the QSystem error model.
     """
+
+    type: Literal["QSystemErrorModel"] = "QSystemErrorModel"
 
     seed: int | None = Field(default=None)
     name: str = "alpha"

--- a/tests/models/test_backend_config.py
+++ b/tests/models/test_backend_config.py
@@ -6,6 +6,18 @@ from pydantic import ValidationError
 from quantinuum_schemas.models.backend_config import (
     AerConfig,
     QuantinuumCompilerOptions,
+    SeleneClassicalReplayConfig,
+    SeleneCoinFlipConfig,
+    SeleneLeanConfig,
+    SeleneQuestConfig,
+    SeleneStimConfig,
+)
+from quantinuum_schemas.models.selene_config import (
+    DepolarizingErrorModel,
+    HeliosRuntime,
+    NoErrorModel,
+    QSystemErrorModel,
+    SimpleRuntime,
 )
 
 
@@ -36,3 +48,38 @@ def test_handling_invalid_option() -> None:
 
     with pytest.raises(ValidationError):
         QuantinuumCompilerOptions(**dict_of_options)
+
+
+@pytest.mark.parametrize("runtime_class", [SimpleRuntime, HeliosRuntime])
+@pytest.mark.parametrize(
+    "error_model_class", [NoErrorModel, DepolarizingErrorModel, QSystemErrorModel]
+)
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        SeleneQuestConfig,
+        SeleneLeanConfig,
+        SeleneCoinFlipConfig,
+        SeleneStimConfig,
+        SeleneClassicalReplayConfig,
+    ],
+)
+def test_selene_roundtrip(
+    config_class: type,
+    runtime_class: type,
+    error_model_class: type,
+) -> None:
+    """Test roundtrip of SeleneConfigs, importantly the ability to discriminate the
+    error model and the runtime."""
+
+    config = config_class(
+        runtime=runtime_class(),
+        error_model=error_model_class(),
+        n_qubits=4,
+    )
+
+    reloaded_config = config_class.model_validate_json(config.model_dump_json())  # type: ignore
+
+    assert config == reloaded_config
+    assert config.runtime == reloaded_config.runtime
+    assert config.error_model == reloaded_config.error_model


### PR DESCRIPTION
Also adopts some of the definitions from nexus-dataclasses in an effort to start using these instead.

Also adds a field that allows Pydantic to know how to deserialise the SeleneConfigs (e.g. which runtime or errormodel)