### PR TITLE
De-duplicating logic where it's shared; keeping it separate where it's not

### DIFF
--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -7,7 +7,7 @@ as our backend credential classes handle those.
 
 # pylint: disable=too-many-lines,no-member
 import abc
-from typing import Any, Dict, Literal, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Literal, Optional, Protocol, Type, TypeVar, Union
 from uuid import UUID
 import warnings
 
@@ -197,7 +197,26 @@ class QuantinuumCompilerOptions(QuantinuumOptions):
     """
 
 
-class QuantinuumConfig(BaseBackendConfig):
+class Batchable(Protocol):
+    batch_id: UUID | None
+    attempt_batching: bool
+
+
+BatchableT = TypeVar("BatchableT", bound=Batchable)
+
+
+class BatchIdValidationMixin:
+    @model_validator(mode="after")
+    def check_batch_id_requires_attempt_batching(self: BatchableT) -> BatchableT:
+        """Fails if batch_id is set and attempt_batching is False."""
+        if self.batch_id is not None and not self.attempt_batching:
+            raise ValueError(
+                "batch id can only be set if attempt_batching is set to True."
+            )
+        return self
+
+
+class QuantinuumConfig(BaseBackendConfig, BatchIdValidationMixin):
     """Runs circuits on Quantinuum's quantum devices and simulators.
 
     Args:
@@ -277,15 +296,6 @@ class QuantinuumConfig(BaseBackendConfig):
                 DeprecationWarning,
             )
 
-        return self
-
-    @model_validator(mode="after")
-    def check_batch_id_requires_attempt_batching(self) -> Self:
-        """Fails if batch_id is set and attempt_batching is False."""
-        if self.batch_id is not None and not self.attempt_batching:
-            raise ValueError(
-                "batch id can only be set if attempt_batching is set to True."
-            )
         return self
 
     @model_validator(mode="after")
@@ -486,7 +496,7 @@ class HeliosEmulatorConfig(BaseEmulatorConfig):
     runtime: HeliosRuntime = Field(default_factory=HeliosRuntime)
 
 
-class HeliosConfig(BaseBackendConfig):
+class HeliosConfig(BaseBackendConfig, BatchIdValidationMixin):
     """Configuration for Helios generation QPUs, emulators and checkers."""
 
     type: Literal["HeliosConfig"] = "HeliosConfig"
@@ -538,15 +548,6 @@ class HeliosConfig(BaseBackendConfig):
                     raise ValueError(
                         f"error_model.seed will be ignored for {self.system_name}"
                     )
-        return self
-
-    @model_validator(mode="after")
-    def check_batch_id_requires_attempt_batching(self) -> Self:
-        """Fails if batch_id is set and attempt_batching is False."""
-        if self.batch_id is not None and not self.attempt_batching:
-            raise ValueError(
-                "batch id can only be set if attempt_batching is set to True."
-            )
         return self
 
     @model_validator(mode="after")

--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -7,7 +7,17 @@ as our backend credential classes handle those.
 
 # pylint: disable=too-many-lines,no-member
 import abc
-from typing import Any, Dict, Literal, Optional, Protocol, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Literal,
+    Optional,
+    Protocol,
+    Type,
+    TypeVar,
+    Union,
+)
 from uuid import UUID
 import warnings
 
@@ -200,6 +210,7 @@ class QuantinuumCompilerOptions(QuantinuumOptions):
 class Batchable(Protocol):
     batch_id: UUID | None
     attempt_batching: bool
+    targets_hardware_device: Callable[..., bool]
 
 
 BatchableT = TypeVar("BatchableT", bound=Batchable)
@@ -212,6 +223,18 @@ class BatchIdValidationMixin:
         if self.batch_id is not None and not self.attempt_batching:
             raise ValueError(
                 "batch id can only be set if attempt_batching is set to True."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def warn_if_backend_doesnt_support_batching(self: BatchableT) -> BatchableT:
+        """Warns if attempt_batching is true for a backend that doesn't support batching"""
+
+        if self.attempt_batching and not self.targets_hardware_device():
+            warnings.warn(
+                f"'{self.__class__.__name__}.attempt_batching' is only supported for hardware backends."
+                "Your job will be submitted as a non-batch job.",
+                RuntimeWarning,
             )
         return self
 
@@ -298,27 +321,15 @@ class QuantinuumConfig(BaseBackendConfig, BatchIdValidationMixin):
 
         return self
 
-    @model_validator(mode="after")
-    def warn_if_backend_doesnt_support_batching(self) -> Self:
-        """Warns if attempt_batching is true for a backend that doesn't support batching"""
-
-        def is_hardware_device(config: QuantinuumConfig) -> bool:
-            """Helper function to identify hardware backends."""
-            if config.device_name.endswith("SC"):
-                return False
-            if config.device_name.endswith("Emulator"):
-                return False
-            if config.device_name.endswith("E"):
-                return False
-            return True
-
-        if self.attempt_batching and not is_hardware_device(self):
-            warnings.warn(
-                "'QuantinuumConfig.attempt_batching' is only supported for hardware backends."
-                "Your job will be submitted as a non-batch job.",
-                RuntimeWarning,
-            )
-        return self
+    def targets_hardware_device(self) -> bool:
+        """Helper function to identify hardware backends."""
+        if self.device_name.endswith("SC"):
+            return False
+        if self.device_name.endswith("Emulator"):
+            return False
+        if self.device_name.endswith("E"):
+            return False
+        return True
 
 
 class IBMQConfig(BaseBackendConfig):
@@ -550,25 +561,13 @@ class HeliosConfig(BaseBackendConfig, BatchIdValidationMixin):
                     )
         return self
 
-    @model_validator(mode="after")
-    def warn_if_backend_doesnt_support_batching(self) -> Self:
-        """Warns if attempt_batching is true for a backend that doesn't support batching"""
-
-        def is_hardware_device(config: HeliosConfig) -> bool:
-            """Helper function to identify hardware backends."""
-            if config.system_name.endswith("SC"):
-                return False
-            if config.emulator_config is not None:
-                return False
-            return True
-
-        if self.attempt_batching and not is_hardware_device(self):
-            warnings.warn(
-                "'HeliosConfig.attempt_batching' is only supported for hardware backends."
-                "Your job will be submitted as a non-batch job.",
-                RuntimeWarning,
-            )
-        return self
+    def targets_hardware_device(self) -> bool:
+        """Helper function to identify hardware backends."""
+        if self.system_name.endswith("SC"):
+            return False
+        if self.emulator_config is not None:
+            return False
+        return True
 
 
 BackendConfig = Annotated[

--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -216,7 +216,7 @@ class Batchable(Protocol):
 BatchableT = TypeVar("BatchableT", bound=Batchable)
 
 
-class BatchIdValidationMixin:
+class BatchingValidationMixin:
     @model_validator(mode="after")
     def check_batch_id_requires_attempt_batching(self: BatchableT) -> BatchableT:
         """Fails if batch_id is set and attempt_batching is False."""
@@ -239,7 +239,7 @@ class BatchIdValidationMixin:
         return self
 
 
-class QuantinuumConfig(BaseBackendConfig, BatchIdValidationMixin):
+class QuantinuumConfig(BaseBackendConfig, BatchingValidationMixin):
     """Runs circuits on Quantinuum's quantum devices and simulators.
 
     Args:
@@ -507,7 +507,7 @@ class HeliosEmulatorConfig(BaseEmulatorConfig):
     runtime: HeliosRuntime = Field(default_factory=HeliosRuntime)
 
 
-class HeliosConfig(BaseBackendConfig, BatchIdValidationMixin):
+class HeliosConfig(BaseBackendConfig, BatchingValidationMixin):
     """Configuration for Helios generation QPUs, emulators and checkers."""
 
     type: Literal["HeliosConfig"] = "HeliosConfig"

--- a/quantinuum_schemas/models/backend_config.py
+++ b/quantinuum_schemas/models/backend_config.py
@@ -232,7 +232,7 @@ class BatchIdValidationMixin:
 
         if self.attempt_batching and not self.targets_hardware_device():
             warnings.warn(
-                f"'{self.__class__.__name__}.attempt_batching' is only supported for hardware backends."
+                "Batching is not supported by this backend. "
                 "Your job will be submitted as a non-batch job.",
                 RuntimeWarning,
             )


### PR DESCRIPTION
`TypeVar` and `Protocol` parts are just for static type checkers