### PR TITLE
fix: Narrow type definition for models.results.QSysShotItemValue

### DIFF
--- a/quantinuum_schemas/models/result.py
+++ b/quantinuum_schemas/models/result.py
@@ -9,7 +9,7 @@ from typing import Annotated, TypeAlias
 from pydantic import StringConstraints
 
 QShotValType: TypeAlias = int | bool | float
-QSysShotItemValue: TypeAlias = QShotValType | list[QShotValType]
+QSysShotItemValue: TypeAlias = QShotValType | list[int] | list[bool] | list[float]
 
 QSysShotItem: TypeAlias = tuple[
     Annotated[str, StringConstraints(max_length=256)], QSysShotItemValue


### PR DESCRIPTION
(Opened a similar ticket in https://github.com/Quantinuum/hugr/pull/3181.)

The existing type definitions:
```
QShotValType: TypeAlias = int | bool | float
QSysShotItemValue: TypeAlias = QShotValType | list[QShotValType]
```

allows for heterogeneous lists of int, bool and/or float because the second definition expands to:
```
int | bool | float | list[int | bool | float]
```

However, our results can only have homogeneous lists (list[int], list[bool], list[float]) so the existing definition is slightly too broad.